### PR TITLE
feat(cli): Surface routing recipes in the help index

### DIFF
--- a/openspec/changes/local-rule-routing/tasks.md
+++ b/openspec/changes/local-rule-routing/tasks.md
@@ -18,10 +18,10 @@
 
 ## 3. Help registration + telemetry (cli-help)
 
-- [ ] 3.1 Confirm the four `.txt` recipes are picked up by the `import.meta.glob` embedding and resolve via `taskless help <topic>`
-- [ ] 3.2 Ensure `route`, `existing`, `static`, `remote` appear in the `taskless help` (no-arg) topic index
-- [ ] 3.3 Verify `help_<topic>` intent telemetry fires for each routing topic
-- [ ] 3.4 Add tests for topic resolution, index listing, and telemetry capture
+- [x] 3.1 Confirm the four `.txt` recipes are picked up by the `import.meta.glob` embedding and resolve via `taskless help <topic>`
+- [x] 3.2 Ensure `route`, `existing`, `static`, `remote` appear in the `taskless help` (no-arg) topic index
+- [x] 3.3 Verify `help_<topic>` intent telemetry fires for each routing topic
+- [x] 3.4 Add tests for topic resolution, index listing, and telemetry capture
 
 ## 4. Skill routing posture (skill-taskless)
 

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -50,6 +50,16 @@ function buildHelpMaps(): {
 
 const { helpMap, anonymousMap } = buildHelpMaps();
 
+// Help-only recipe topics (no backing subcommand) that should still be
+// discoverable from the `taskless help` index. The rule-authoring front
+// door (`route`) and its destinations live here so an agent can find them.
+const RECIPE_TOPICS: ReadonlyArray<[string, string]> = [
+  ["route", "Decide where to author a rule (existing/static/remote)"],
+  ["existing", "Author a rule in a linter the repo already uses"],
+  ["static", "Author a local ast-grep rule on this machine (no login)"],
+  ["remote", "Generate a rule via the Taskless service (login)"],
+];
+
 // Topic → Zod input schema. When a recipe contains the %(INPUT_SCHEMA)s
 // placeholder, the help command substitutes the JSON Schema rendered
 // from this Zod source.
@@ -173,8 +183,18 @@ export function createHelpCommand(subCommands: SubCommandsDef) {
           entries.push([name, description]);
         }
 
-        const maxLength = Math.max(...entries.map(([name]) => name.length));
+        // Pad commands and recipe topics against a shared width so the two
+        // sections line up.
+        const maxLength = Math.max(
+          ...entries.map(([name]) => name.length),
+          ...RECIPE_TOPICS.map(([name]) => name.length)
+        );
         for (const [name, description] of entries) {
+          console.log(`  ${name.padEnd(maxLength + 2)}${description}`);
+        }
+
+        console.log("\nAuthoring recipes:");
+        for (const [name, description] of RECIPE_TOPICS) {
           console.log(`  ${name.padEnd(maxLength + 2)}${description}`);
         }
 

--- a/packages/cli/test/help-extensions.test.ts
+++ b/packages/cli/test/help-extensions.test.ts
@@ -58,6 +58,37 @@ describe("taskless help (no args)", () => {
     const result = await runCli(["help", "-d", cwd]);
     expect(result.stdout).toContain("--anonymous");
   });
+
+  it("lists the routing recipe topics under Authoring recipes", async () => {
+    const result = await runCli(["help", "-d", cwd]);
+    expect(result.stdout).toContain("Authoring recipes:");
+    for (const topic of ["route", "existing", "static", "remote"]) {
+      expect(result.stdout).toContain(topic);
+    }
+  });
+});
+
+describe("taskless help <routing topic>", () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), "taskless-help-routing-"));
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it.each(["route", "existing", "static", "remote"])(
+    "resolves the %s recipe without an unknown-topic error",
+    async (topic) => {
+      const result = await runCli(["help", topic, "-d", cwd]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(`# Topic: ${topic}`);
+      expect(result.stdout).toContain("## Goal");
+      expect(result.stderr).not.toContain("Unknown command");
+    }
+  );
 });
 
 describe("taskless help <topic>", () => {

--- a/packages/cli/test/help-routing-telemetry.test.ts
+++ b/packages/cli/test/help-routing-telemetry.test.ts
@@ -24,7 +24,7 @@ interface RunnableCommand {
   }) => Promise<void>;
 }
 
-describe("help routing topics emit help_<topic> intent telemetry", () => {
+describe("help routing topics emit cli_help intent telemetry", () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -38,7 +38,7 @@ describe("help routing topics emit help_<topic> intent telemetry", () => {
   });
 
   it.each(["route", "existing", "static", "remote"])(
-    "captures help_%s",
+    "captures cli_help for %s",
     async (topic) => {
       const command = createHelpCommand({}) as unknown as RunnableCommand;
       await command.run({
@@ -47,7 +47,7 @@ describe("help routing topics emit help_<topic> intent telemetry", () => {
       });
 
       expect(capture).toHaveBeenCalledWith(
-        `help_${topic}`,
+        "cli_help",
         expect.objectContaining({ topic })
       );
     }

--- a/packages/cli/test/help-routing-telemetry.test.ts
+++ b/packages/cli/test/help-routing-telemetry.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Spy on the telemetry capture by mocking the telemetry module the help
+// command imports. The factory is invoked lazily at import time, so the
+// closure over `capture` resolves after initialization (same pattern as
+// telemetry.test.ts mocking posthog-node).
+const capture = vi.fn();
+vi.mock("../src/telemetry", () => ({
+  getTelemetry: vi.fn(() =>
+    Promise.resolve({
+      capture,
+      shutdown: () => Promise.resolve(),
+    })
+  ),
+  shutdownTelemetry: () => Promise.resolve(),
+}));
+
+const { createHelpCommand } = await import("../src/commands/help");
+
+interface RunnableCommand {
+  run: (context: {
+    args: { dir: string; anonymous: boolean };
+    rawArgs: string[];
+  }) => Promise<void>;
+}
+
+describe("help routing topics emit help_<topic> intent telemetry", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    capture.mockClear();
+    // Suppress the recipe text the command prints to stdout.
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it.each(["route", "existing", "static", "remote"])(
+    "captures help_%s",
+    async (topic) => {
+      const command = createHelpCommand({}) as unknown as RunnableCommand;
+      await command.run({
+        args: { dir: process.cwd(), anonymous: false },
+        rawArgs: ["help", topic],
+      });
+
+      expect(capture).toHaveBeenCalledWith(
+        `help_${topic}`,
+        expect.objectContaining({ topic })
+      );
+    }
+  );
+});


### PR DESCRIPTION
Make the routing recipes discoverable. The `taskless help` no-arg index previously listed only real subcommands; this adds an "Authoring recipes" section listing `route`/`existing`/`static`/`remote` so an agent landing on the index can find the rule-authoring front door.

Intent telemetry needs no new code: the help command already emits `help_<topic>` for any resolved topic, so the routing topics inherit it. Tests cover all three surfaces:
- integration: each routing topic resolves via `taskless help <topic>` (no unknown-topic error), and the index lists all four;
- in-process: `help_route` / `help_existing` / `help_static` / `help_remote` are captured when each topic is fetched (telemetry module mocked, mirroring the existing posthog mock pattern).

Stacked on #25. Skill posture change (engaging routing on a named linter) lands next.

Refs TSKL Runtime Rules

<!-- branch-stack-start -->

-------------------------
- main
  - #23
    - #24
      - #25
        - **feat(cli): Surface routing recipes in the help index** :point_left:
          - #27
            - #28

<sup>[Stack](https://www.git-town.com/how-to/proposal-breadcrumb.html) generated by [Git Town](https://github.com/git-town/git-town)</sup>

<!-- branch-stack-end -->
