### PR TITLE
chore(config): Allow git-town in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,7 +30,8 @@
       "Bash(find skills -name \"SKILL.md\" -exec grep -l \"optional\\\\|required\" {} \\\\;)",
       "Skill(pr-writer)",
       "Skill(pr-writer:*)",
-      "WebSearch"
+      "WebSearch",
+      "Bash(git-town:*)"
     ],
     "deny": [
       "AskUserQuestion*",


### PR DESCRIPTION
Add `Bash(git-town:*)` to the project `.claude/settings.json` allow list.

Git Town manages the stacked feature branches used in this repo's workflow; allowing it avoids a per-invocation permission prompt. Single-line settings change, no code impact.