### PR TITLE
ref(cli): Drop unused installedAt timestamp from install manifest

### DIFF
--- a/.changeset/drop-installed-at.md
+++ b/.changeset/drop-installed-at.md
@@ -1,0 +1,11 @@
+---
+"@taskless/cli": patch
+---
+
+Drop the unused `installedAt` timestamp from the install manifest.
+
+The timestamp was written into `.taskless/taskless.json` on every install but
+never read, so it only produced spurious diffs in committed manifests (e.g.
+after `pnpm build:self`). A new schema migration (v3) strips it from existing
+manifests, and install output is now deterministic. No user-facing behavior
+changes.

--- a/packages/cli/src/filesystem/migrate.ts
+++ b/packages/cli/src/filesystem/migrate.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { Migrations } from "./types";
 import init from "./migrations/0001-init";
 import installMigration from "./migrations/0002-install";
+import dropInstalledAt from "./migrations/0003-drop-installed-at";
 
 export interface TasklessInstallTarget {
   skills?: string[];
@@ -17,7 +18,6 @@ export interface TasklessInstallTarget {
 }
 
 export interface TasklessInstallManifest {
-  installedAt?: string;
   cliVersion?: string;
   targets?: Record<string, TasklessInstallTarget>;
   onboarded?: boolean;
@@ -33,6 +33,7 @@ const MANIFEST_FILE = "taskless.json";
 const migrations: Migrations = {
   "1": init,
   "2": installMigration,
+  "3": dropInstalledAt,
 };
 
 /** Sort migration keys numerically and return [version, migration] pairs */

--- a/packages/cli/src/filesystem/migrations/0003-drop-installed-at.ts
+++ b/packages/cli/src/filesystem/migrations/0003-drop-installed-at.ts
@@ -1,0 +1,40 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { Migration } from "../types";
+
+const MANIFEST_FILE = "taskless.json";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Migration 3 — drop the unused `install.installedAt` timestamp.
+ *
+ * The timestamp was written on every install but never read, so it only
+ * produced spurious diffs in committed manifests (e.g. on `pnpm build:self`).
+ * Idempotent: a manifest already lacking the field is left untouched.
+ */
+const migration: Migration = async (directory) => {
+  const manifestPath = join(directory, MANIFEST_FILE);
+  let raw: Record<string, unknown> = {};
+  try {
+    const content = await readFile(manifestPath, "utf8");
+    const parsed = JSON.parse(content) as unknown;
+    if (isPlainObject(parsed)) {
+      raw = parsed;
+    }
+  } catch {
+    // Missing or unparseable — nothing to strip.
+    return;
+  }
+
+  const install = raw.install;
+  if (isPlainObject(install) && "installedAt" in install) {
+    delete install.installedAt;
+    await writeFile(manifestPath, JSON.stringify(raw, null, 2) + "\n", "utf8");
+  }
+};
+
+export default migration;

--- a/packages/cli/src/install/install.ts
+++ b/packages/cli/src/install/install.ts
@@ -304,7 +304,6 @@ export function planToStateTargets(plan: InstallPlan): InstallState["targets"] {
 
 export interface ApplyInstallOptions {
   cliVersion: string;
-  now?: () => Date;
 }
 
 export interface ApplyInstallResult {
@@ -444,10 +443,8 @@ export async function applyInstallPlan(
   options: ApplyInstallOptions
 ): Promise<ApplyInstallResult> {
   const previousState = await readInstallState(cwd);
-  const now = options.now ?? (() => new Date());
 
   const nextState: InstallState = {
-    installedAt: now().toISOString(),
     cliVersion: options.cliVersion,
     targets: planToStateTargets(plan),
   };

--- a/packages/cli/src/install/state.ts
+++ b/packages/cli/src/install/state.ts
@@ -27,7 +27,6 @@ export interface InstallTargetRecord {
 }
 
 export interface InstallState {
-  installedAt?: string;
   cliVersion?: string;
   targets: Record<string, InstallTargetRecord>;
 }
@@ -67,7 +66,6 @@ function toInstallState(
     }
   }
   return {
-    installedAt: install?.installedAt,
     cliVersion: install?.cliVersion,
     targets,
   };
@@ -83,7 +81,6 @@ function toInstallManifest(state: InstallState): TasklessInstallManifest {
     targets[name] = entry;
   }
   const manifest: TasklessInstallManifest = { targets };
-  if (state.installedAt) manifest.installedAt = state.installedAt;
   if (state.cliVersion) manifest.cliVersion = state.cliVersion;
   return manifest;
 }

--- a/packages/cli/src/wizard/index.ts
+++ b/packages/cli/src/wizard/index.ts
@@ -63,7 +63,6 @@ export async function runWizard(
 
     const previousState = await readInstallState(options.cwd);
     const diff = computeInstallDiff(previousState, {
-      installedAt: previousState.installedAt,
       cliVersion: previousState.cliVersion,
       targets: planToStateTargets(plan),
     });

--- a/packages/cli/test/apply-install-plan.test.ts
+++ b/packages/cli/test/apply-install-plan.test.ts
@@ -148,7 +148,6 @@ describe("applyInstallPlan", () => {
   it("never deletes the canonical store while cleaning another target", async () => {
     // Prior install recorded an obsolete skill under .claude.
     await writeInstallState(cwd, {
-      installedAt: "2026-04-01T00:00:00.000Z",
       cliVersion: "0.6.0",
       targets: {
         ".claude": {
@@ -200,7 +199,6 @@ describe("applyInstallPlan", () => {
     }
 
     await writeInstallState(cwd, {
-      installedAt: "2026-04-17T00:00:00.000Z",
       cliVersion: "0.6.0",
       targets: {
         ".claude": { skills: v6Skills, commands: v6Commands },

--- a/packages/cli/test/init-no-interactive.test.ts
+++ b/packages/cli/test/init-no-interactive.test.ts
@@ -139,7 +139,7 @@ describe("taskless init --no-interactive", () => {
       await readFile(join(cwd, ".taskless", "taskless.json"), "utf8")
     ) as { version: number; install: Record<string, unknown> };
 
-    expect(manifest.version).toBe(2);
+    expect(manifest.version).toBe(3);
     expect(manifest.install).toBeDefined();
   });
 

--- a/packages/cli/test/install-state.test.ts
+++ b/packages/cli/test/install-state.test.ts
@@ -131,7 +131,6 @@ describe("readInstallState / writeInstallState", () => {
 
   it("round-trips through write then read", async () => {
     const state: InstallState = {
-      installedAt: "2026-04-16T12:00:00.000Z",
       cliVersion: "0.5.4",
       targets: {
         ".claude": {

--- a/packages/cli/test/migrate-install.test.ts
+++ b/packages/cli/test/migrate-install.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { ensureTasklessDirectory } from "../src/filesystem/directory";
 import { readManifest, writeManifest } from "../src/filesystem/migrate";
 
-describe("migration 2 — install state", () => {
+describe("install-state migrations", () => {
   let temporaryDirectory: string;
 
   beforeEach(async () => {
@@ -19,7 +19,7 @@ describe("migration 2 — install state", () => {
     await rm(temporaryDirectory, { recursive: true, force: true });
   });
 
-  it("fresh project reaches { version: 2, install: {} }", async () => {
+  it("fresh project reaches { version: 3, install: {} }", async () => {
     await ensureTasklessDirectory(temporaryDirectory);
 
     const manifest = JSON.parse(
@@ -29,7 +29,7 @@ describe("migration 2 — install state", () => {
       )
     ) as { version: number; install: Record<string, unknown> };
 
-    expect(manifest.version).toBe(2);
+    expect(manifest.version).toBe(3);
     expect(manifest.install).toEqual({});
   });
 
@@ -48,24 +48,24 @@ describe("migration 2 — install state", () => {
       await readFile(join(tasklessDirectory, "taskless.json"), "utf8")
     ) as { version: number; install: Record<string, unknown> };
 
-    expect(manifest.version).toBe(2);
+    expect(manifest.version).toBe(3);
     expect(manifest.install).toEqual({});
   });
 
-  it("preserves an existing install object on re-run", async () => {
+  it("drops installedAt but preserves other install fields on re-run", async () => {
     const tasklessDirectory = join(temporaryDirectory, ".taskless");
     await mkdir(tasklessDirectory, { recursive: true });
 
-    const existingInstall = {
-      installedAt: "2026-04-16T00:00:00.000Z",
-      cliVersion: "0.5.4",
-      targets: {
-        ".claude": { skills: ["taskless-check"] },
-      },
-    };
     await writeFile(
       join(tasklessDirectory, "taskless.json"),
-      JSON.stringify({ version: 2, install: existingInstall }),
+      JSON.stringify({
+        version: 2,
+        install: {
+          installedAt: "2026-04-16T00:00:00.000Z",
+          cliVersion: "0.5.4",
+          targets: { ".claude": { skills: ["taskless-check"] } },
+        },
+      }),
       "utf8"
     );
 
@@ -73,10 +73,14 @@ describe("migration 2 — install state", () => {
 
     const manifest = JSON.parse(
       await readFile(join(tasklessDirectory, "taskless.json"), "utf8")
-    ) as { version: number; install: typeof existingInstall };
+    ) as { version: number; install: Record<string, unknown> };
 
-    expect(manifest.version).toBe(2);
-    expect(manifest.install).toEqual(existingInstall);
+    // Migration 3 strips the unused timestamp; everything else survives.
+    expect(manifest.version).toBe(3);
+    expect(manifest.install).toEqual({
+      cliVersion: "0.5.4",
+      targets: { ".claude": { skills: ["taskless-check"] } },
+    });
   });
 
   it("preserves unknown top-level fields through migrate + write cycle", async () => {
@@ -98,7 +102,7 @@ describe("migration 2 — install state", () => {
       await readFile(join(tasklessDirectory, "taskless.json"), "utf8")
     ) as Record<string, unknown>;
 
-    expect(manifest.version).toBe(2);
+    expect(manifest.version).toBe(3);
     expect(manifest.install).toEqual({});
     expect(manifest.experimental).toEqual({
       flag: true,
@@ -120,7 +124,7 @@ describe("migration 2 — install state", () => {
       await readFile(join(tasklessDirectory, "taskless.json"), "utf8")
     ) as { version: number; install: Record<string, unknown> };
 
-    expect(manifest.version).toBe(2);
+    expect(manifest.version).toBe(3);
     expect(manifest.install).toEqual({});
   });
 
@@ -185,7 +189,7 @@ describe("migration version matrix", () => {
   // Seed .taskless/ at every prior schema version and confirm each
   // forward-migrates cleanly to the latest. Catches a future migration that
   // forgets to handle an older starting point.
-  for (const startVersion of [0, 1, 2]) {
+  for (const startVersion of [0, 1, 2, 3]) {
     it(`forward-migrates a v${String(startVersion)} project to the latest schema`, async () => {
       const latest = await latestSchemaVersion();
       const tasklessDirectory = join(temporaryDirectory, ".taskless");

--- a/packages/cli/test/onboard.test.ts
+++ b/packages/cli/test/onboard.test.ts
@@ -57,7 +57,7 @@ describe("taskless onboard", () => {
     expect(stdout).toContain("## Goal");
 
     const manifest = await readJsonManifest(cwd);
-    expect(manifest.version).toBe(2);
+    expect(manifest.version).toBe(3);
     // init/onboard alone should not record onboarded
     const install = manifest.install as { onboarded?: boolean } | undefined;
     expect(install?.onboarded).toBeUndefined();
@@ -123,7 +123,6 @@ describe("taskless onboard", () => {
       JSON.stringify({
         version: 2,
         install: {
-          installedAt: "2026-04-16T00:00:00.000Z",
           cliVersion: "0.7.0",
           targets: { ".claude": { skills: ["taskless"], commands: ["tskl"] } },
         },
@@ -143,12 +142,10 @@ describe("taskless onboard", () => {
     const manifest = await readJsonManifest(cwd);
     const install = manifest.install as {
       onboarded?: boolean;
-      installedAt?: string;
       cliVersion?: string;
       targets?: Record<string, unknown>;
     };
     expect(install.onboarded).toBe(true);
-    expect(install.installedAt).toBe("2026-04-16T00:00:00.000Z");
     expect(install.cliVersion).toBe("0.7.0");
     expect(install.targets).toEqual({
       ".claude": { skills: ["taskless"], commands: ["tskl"] },

--- a/packages/cli/test/wizard-integration.test.ts
+++ b/packages/cli/test/wizard-integration.test.ts
@@ -150,7 +150,6 @@ describe("runWizard end-to-end", () => {
     await ensureTasklessDirectory(cwd);
     const { writeInstallState } = await import("../src/install/state");
     await writeInstallState(cwd, {
-      installedAt: "2026-05-10T00:00:00.000Z",
       cliVersion: "0.5.4",
       targets: {
         ".claude": {


### PR DESCRIPTION
Remove the `installedAt` timestamp from the install manifest. It was written into `.taskless/taskless.json` on every install but never read by anything, so it only produced spurious diffs in committed manifests (surfaced while dogfooding via `pnpm build:self` — see #42).

## What

- **Drop `installedAt`** from `InstallState`, the manifest type, the read path, and the write path.
- **Retire the injectable `now` option** on `applyInstallPlan` — the timestamp was its only consumer, so manifest writes are now fully **deterministic**.
- **Schema migration v3** (`0003-drop-installed-at.ts`) strips the field from existing manifests; idempotent, and forward-migrates cleanly from every prior version.
- Tests updated: fixtures/assertions dropped the field, a migration test now asserts v3 strips `installedAt` while preserving other install fields, the version matrix covers a v3 start, and the two fresh-install version assertions bump 2→3.

## Why

`installedAt` had no readers — confirmed by tracing every reference (all writes/pass-through). Removing it eliminates the per-run churn the manifest produced on re-install/dogfood.

## Scope

This addresses the **timestamp** specifically (per-run churn). A real install still rewrites `cliVersion`/target-modes when those actually change — that's the broader "separate stable config from volatile install metadata" question in #42, intentionally left out here. The repo's own committed `taskless.json` is not hand-migrated; it upgrades lazily on next install.

## Review notes

- Non-breaking → **patch** changeset. Existing manifests migrate automatically (v2 → v3).
- A v3 manifest read by an older CLI is tolerated (its migration runner sees `version >= max` and no-ops).

Refs #42