### PR TITLE
ref(cli): Give dev/self build targets their own output dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@
 # Dependencies
 node_modules/
 
-# Build output
+# Build output (prod, dev, and self targets each emit to their own directory)
 **/dist/
+**/dist-dev/
+**/dist-self/
 *.tsbuildinfo
 .turbo/
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,15 @@ The CLI bakes its own invocation string into the skill, command, and recipe
 content it installs. Three build targets pick that string, all driven by the
 `TASKLESS_BUILD_TARGET` env var via Vite `define` (same source files, no edits):
 
-| Command           | Baked invocation                        | Use for                                                                              |
-| ----------------- | --------------------------------------- | ------------------------------------------------------------------------------------ |
-| `pnpm build`      | `npx @taskless/cli`                     | Production / published builds (default).                                             |
-| `pnpm build:dev`  | `node <abs>/packages/cli/dist/index.js` | Validating this build from **another** repo (absolute path resolves anywhere).       |
-| `pnpm build:self` | `node packages/cli/dist/index.js`       | Dogfooding **in this repo** (path is repo-root-relative; run the CLI from the root). |
+Each target also emits to its own directory so the three never overwrite one
+another — prod → `dist/`, dev → `dist-dev/`, self → `dist-self/` (all
+gitignored):
+
+| Command           | Output dir   | Baked invocation                            | Use for                                                                              |
+| ----------------- | ------------ | ------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `pnpm build`      | `dist/`      | `npx @taskless/cli`                         | Production / published builds (default).                                             |
+| `pnpm build:dev`  | `dist-dev/`  | `node <abs>/packages/cli/dist-dev/index.js` | Validating this build from **another** repo (absolute path resolves anywhere).       |
+| `pnpm build:self` | `dist-self/` | `node packages/cli/dist-self/index.js`      | Dogfooding **in this repo** (path is repo-root-relative; run the CLI from the root). |
 
 `pnpm build:self` builds the CLI with the relative invocation and then runs
 `taskless init --no-interactive` to install into this repo — so `.claude` gets

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,8 @@ export default tseslint.config(
     ignores: [
       "node_modules/",
       "**/dist/",
+      "**/dist-dev/",
+      "**/dist-self/",
       "**/*.config.js",
       "**/*.config.ts",
       ".lintstagedrc.js",

--- a/openspec/specs/infrastructure/spec.md
+++ b/openspec/specs/infrastructure/spec.md
@@ -102,7 +102,7 @@ The repository SHALL have `turbo` as a root devDependency and a `turbo.json` con
 
 ### Requirement: Build pipeline runs across all packages
 
-The root `pnpm build` command SHALL invoke `turbo run build`, which runs the `build` script in every workspace package that defines one. Build outputs (`dist/**`) SHALL be cached.
+The root `pnpm build` command SHALL invoke `turbo run build`, which runs the `build` script in every workspace package that defines one. Build outputs (`dist/**`, `dist-dev/**`, `dist-self/**`) SHALL be cached.
 
 #### Scenario: Root build command runs CLI build
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:dev": "pnpm --filter @taskless/cli build:dev",
     "build:self": "run-s build:self:compile build:self:install",
     "build:self:compile": "pnpm --filter @taskless/cli build:self",
-    "build:self:install": "node packages/cli/dist/index.js init --no-interactive",
+    "build:self:install": "node packages/cli/dist-self/index.js init --no-interactive",
     "bump": "run-s bump:version bump:sync",
     "bump:sync": "tsx scripts/sync-skill-versions.ts",
     "bump:version": "changeset version",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -8,5 +8,5 @@
     "noUncheckedIndexedAccess": true
   },
   "include": ["src", "test", "scripts"],
-  "exclude": ["node_modules", "dist", "test/fixtures"]
+  "exclude": ["node_modules", "dist", "dist-dev", "dist-self", "test/fixtures"]
 }

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -12,18 +12,37 @@ const pkg = JSON.parse(
   readFileSync(resolve(import.meta.dirname, "package.json"), "utf8")
 ) as { version: string };
 
+// Each build target emits to its own directory so prod, dev, and self builds
+// never overwrite one another. Keyed by TASKLESS_BUILD_TARGET; anything other
+// than "dev"/"self" is treated as prod.
+const OUT_DIRS = {
+  prod: "dist",
+  dev: "dist-dev",
+  self: "dist-self",
+} as const;
+
+function resolveBuildTarget(): keyof typeof OUT_DIRS {
+  const target = process.env.TASKLESS_BUILD_TARGET;
+  return target === "dev" || target === "self" ? target : "prod";
+}
+
+function resolveOutDir(): string {
+  return OUT_DIRS[resolveBuildTarget()];
+}
+
 // The CLI invocation baked into emitted skill/command/recipe content, chosen
 // by the TASKLESS_BUILD_TARGET env var (see package.json build:dev/build:self):
 //   - prod (default): the published `npx @taskless/cli`
 //   - dev:  an absolute path, for validating this build from another repo
 //   - self: a repo-root-relative path, for dogfooding inside this repo
+// The dev/self paths point at their own output directory (dist-dev/dist-self).
 function resolveCliInvocation(): string {
-  switch (process.env.TASKLESS_BUILD_TARGET) {
+  switch (resolveBuildTarget()) {
     case "self": {
-      return "node packages/cli/dist/index.js";
+      return `node packages/cli/${OUT_DIRS.self}/index.js`;
     }
     case "dev": {
-      return `node ${resolve(import.meta.dirname, "dist/index.js")}`;
+      return `node ${resolve(import.meta.dirname, OUT_DIRS.dev, "index.js")}`;
     }
     default: {
       return "npx @taskless/cli";
@@ -125,7 +144,7 @@ function shebang(): Plugin {
     writeBundle(options, bundle) {
       for (const [fileName, chunk] of Object.entries(bundle)) {
         if (chunk.type === "chunk" && chunk.isEntry) {
-          const outPath = resolve(options.dir ?? "dist", fileName);
+          const outPath = resolve(options.dir ?? resolveOutDir(), fileName);
           chmodSync(outPath, 0o755);
         }
       }
@@ -141,6 +160,7 @@ export default defineConfig({
   },
   plugins: [tsconfigPaths(), assertSkillVersions(), shebang()],
   build: {
+    outDir: resolveOutDir(),
     lib: {
       entry: resolve(import.meta.dirname, "src/index.ts"),
       formats: ["es"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true
   },
-  "exclude": ["node_modules", "dist", "packages"]
+  "exclude": ["node_modules", "dist", "dist-dev", "dist-self", "packages"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "outputs": ["dist/**"],
+      "outputs": ["dist/**", "dist-dev/**", "dist-self/**"],
       "env": ["TASKLESS_BUILD_TARGET"]
     },
     "test": {


### PR DESCRIPTION
## What

Each build target now emits to a distinct, gitignored directory so prod, dev, and self builds never overwrite one another:

| Command | Output dir | Baked invocation | Use for |
| --- | --- | --- | --- |
| `pnpm build` | `dist/` | `npx @taskless/cli` | Production / published builds (default) |
| `pnpm build:dev` | `dist-dev/` | `node <abs>/…/dist-dev/index.js` | Validating this build from another repo |
| `pnpm build:self` | `dist-self/` | `node packages/cli/dist-self/index.js` | Dogfooding in this repo |

## Why

Previously all three targets wrote to `dist/`, so a `build:dev` or `build:self` would clobber the prod artifact (and each other). Splitting the output directories makes the three reliable and independent — you can have a prod build and a self-install build coexisting without re-running.

## How

- `vite.config.ts` maps `TASKLESS_BUILD_TARGET` to its `outDir` via a shared `OUT_DIRS` table that also drives the baked dev/self invocation paths — output location and embedded CLI path stay in sync from one source.
- **Prod is unchanged** (still `dist/`), so the published package, `pnpm cli`, and every test `binPath` keep working untouched — the diff only adds the two new dirs.
- `turbo` outputs, `.gitignore`, eslint ignores, and both `tsconfig` excludes cover `dist-dev/`/`dist-self/`.
- README table + the infrastructure spec document the three-target layout.

No changeset: the published artifact is byte-identical (prod still `dist/`), so this is consumer-invisible build plumbing.

## Verification

- `pnpm build` / `build:dev` / `build:self` each land in their own dir with the correct baked invocation string (verified prod=`npx @taskless/cli`, dev=absolute, self=repo-relative).
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (299 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)