### PR TITLE
ci: add Copilot review instructions for GHA credential safety

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,10 +25,11 @@ them as security-sensitive and flag the following:
   (changeset text, PR bodies, uploaded artifacts). Prefer splitting into a
   credential-free job that handles untrusted content and a separate credentialed
   job that only runs reviewed, merged source.
-- **Over-broad `permissions:`.** Flag missing top-level `permissions:` (defaults
-  are broad) and any grant not justified by the job — call out `contents: write`,
-  `id-token: write`, `packages: write`, `actions: write`. Prefer least privilege,
-  set per job.
+- **Over-broad or implicit `permissions:`.** Prefer an explicit least-privilege
+  `permissions:` block over relying on the repo/org default token scope, which
+  varies by settings and may grant more than the job needs. Flag any grant not
+  justified by the job — call out `contents: write`, `id-token: write`,
+  `packages: write`, `actions: write` — and prefer setting permissions per job.
 - **Unpinned actions.** In any workflow that touches secrets or OIDC, flag
   third-party actions pinned to a tag or branch (`@v4`, `@main`) instead of a
   full commit SHA.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,49 @@
+# Copilot review instructions
+
+Repo-wide guidance for automated code review. Prioritize correctness and
+security over style. Be specific and actionable; cite the file and line.
+
+## GitHub Actions — credential & secret safety (review with extra scrutiny)
+
+Workflows under `.github/workflows/` can hold high-value credentials
+(`GITHUB_TOKEN`, `NPM_TOKEN`, OIDC identities, deploy keys). Treat any change to
+them as security-sensitive and flag the following:
+
+- **`pull_request_target` + PR-controlled code or secrets.** Flag any
+  `pull_request_target` (or `workflow_run`) workflow that checks out the PR head
+  and then builds/tests it, or exposes secrets to it. A fork PR can then run its
+  own code with the base repo's token. Prefer `pull_request` (forks get a
+  read-only token and no secrets).
+- **Untrusted `${{ }}` interpolated into `run:`.** Flag any expression carrying
+  attacker-controllable text — `github.event.pull_request.title`/`.body`,
+  `.head_commit.message`, `.head_ref`/branch names, issue/comment/review bodies —
+  substituted directly into a shell `run:` step. That is command injection.
+  Require it be passed via `env:` and referenced as a quoted `"$VAR"`, or handled
+  in `actions/github-script` via `process.env`.
+- **Credentials exposed alongside untrusted content.** Flag a job that holds a
+  publish/deploy secret AND processes PR- or contributor-authored content
+  (changeset text, PR bodies, uploaded artifacts). Prefer splitting into a
+  credential-free job that handles untrusted content and a separate credentialed
+  job that only runs reviewed, merged source.
+- **Over-broad `permissions:`.** Flag missing top-level `permissions:` (defaults
+  are broad) and any grant not justified by the job — call out `contents: write`,
+  `id-token: write`, `packages: write`, `actions: write`. Prefer least privilege,
+  set per job.
+- **Unpinned actions.** In any workflow that touches secrets or OIDC, flag
+  third-party actions pinned to a tag or branch (`@v4`, `@main`) instead of a
+  full commit SHA.
+- **Lifecycle scripts under a live credential.** Flag dependency installs that
+  run lifecycle scripts (no `--ignore-scripts`) in a job that holds a publish
+  token or OIDC identity — a malicious/compromised dependency could exfiltrate
+  it. Prefer `--ignore-scripts` + an explicit, reviewed build step.
+- **Long-lived stored tokens.** Where a registry supports it (e.g. npm trusted
+  publishing), prefer short-lived OIDC over a stored `NPM_TOKEN`/PAT, and flag
+  new long-lived secrets that could be replaced by OIDC.
+
+## Secrets & credentials (all code)
+
+- Flag hardcoded secrets, tokens, private keys, or credentials in source,
+  tests, fixtures, or committed config. Never read or echo `.env` / `.dev.vars`
+  / `.secrets`.
+- Flag logging or error messages that could print a token, Authorization header,
+  cookie, or other secret.


### PR DESCRIPTION
Makes security review of GitHub Actions a **standing, per-PR control** instead of something we remember to request. GitHub Copilot code review reads `.github/copilot-instructions.md` repo-wide, so this directs it to scrutinize workflow changes for the token-exfiltration classes we care about:

- `pull_request_target` (or `workflow_run`) that checks out/builds PR code or exposes secrets to it
- untrusted `${{ }}` (PR title/body, commit message, branch name, issue/comment bodies) interpolated into `run:` — command injection
- a credential sharing a job with untrusted/contributor content (prefer split jobs)
- over-broad `permissions:` (missing top-level block; unjustified `contents: write` / `id-token: write` / `packages: write` / `actions: write`)
- third-party actions unpinned from a commit SHA in credentialed workflows
- dependency lifecycle scripts running under a live publish token/OIDC (prefer `--ignore-scripts` + explicit build)
- long-lived stored tokens where OIDC trusted publishing would do

Plus a short general secrets-in-code note (hardcoded secrets, logging tokens, never read `.env`/`.dev.vars`/`.secrets`).

Companion to the release-workflow PR (#57): that PR is the first thing these instructions would guard, and per our discussion this is the "target security / key extraction on any GHA exposing tokens" control we said we should have anyway.

Draft for review of the wording/scope — no code impact.