### PR TITLE
docs: Harden stacked-PR recovery to resolve merge SHA from the PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,11 @@ Stacked branches share commits (each child contains its ancestors). Prefer expli
 
 ### Recovery if a child PR gets closed by base-branch deletion
 
-1. Restore the deleted base branch ref at the merge commit's second parent:
-   `gh api --method POST repos/<owner>/<repo>/git/refs -f ref=refs/heads/<branch> -f sha=$(git rev-parse origin/main^2)`
+1. Restore the deleted base branch ref at the child's merge commit's second parent. Resolve the merge commit from the closed PR itself — do **not** use `origin/main^2`, which is only that second parent while the merge is still `main`'s tip (any later merge, or a squash/rebase tip, makes it the wrong SHA):
+   ```bash
+   MERGE_SHA=$(gh pr view <n> --repo <owner>/<repo> --json mergeCommit --jq .mergeCommit.oid)
+   gh api --method POST repos/<owner>/<repo>/git/refs -f ref=refs/heads/<branch> -f sha=$(git rev-parse "$MERGE_SHA^2")
+   ```
 2. Reopen the child via **REST** (GraphQL `gh pr reopen` fails on the Projects-classic deprecation):
    `gh api --method PATCH repos/<owner>/<repo>/pulls/<n> -f state=open`
 3. Retarget it: `gh pr edit <n> --base main` (only works once it's open).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,14 +66,16 @@ Stacked branches share commits (each child contains its ancestors). Prefer expli
 
 ### Recovery if a child PR gets closed by base-branch deletion
 
-1. Restore the deleted base branch ref at the child's merge commit's second parent. Resolve the merge commit from the closed PR itself — do **not** use `origin/main^2`, which is only that second parent while the merge is still `main`'s tip (any later merge, or a squash/rebase tip, makes it the wrong SHA):
+This happens when the **parent** PR is merged with `--delete-branch`: deleting the parent's head branch (which is the child's base) closes the **child** PR. Two PRs are involved — the merged parent (`<parent>`) and the closed child (`<child>`); `<branch>` is the deleted base, i.e. the parent's head branch.
+
+1. Restore the deleted base branch ref at the **parent** merge commit's second parent (the deleted branch's pre-merge tip). Resolve the merge commit from `<parent>` — the PR that actually merged — **not** the closed child (it's unmerged, so its `mergeCommit` is `null` and `git rev-parse` would fail), and **not** `origin/main^2` (only that second parent while the parent merge is still `main`'s tip; any later merge, or a squash/rebase tip, makes it the wrong SHA):
    ```bash
-   MERGE_SHA=$(gh pr view <n> --repo <owner>/<repo> --json mergeCommit --jq .mergeCommit.oid)
+   MERGE_SHA=$(gh pr view <parent> --repo <owner>/<repo> --json mergeCommit --jq .mergeCommit.oid)
    gh api --method POST repos/<owner>/<repo>/git/refs -f ref=refs/heads/<branch> -f sha=$(git rev-parse "$MERGE_SHA^2")
    ```
 2. Reopen the child via **REST** (GraphQL `gh pr reopen` fails on the Projects-classic deprecation):
-   `gh api --method PATCH repos/<owner>/<repo>/pulls/<n> -f state=open`
-3. Retarget it: `gh pr edit <n> --base main` (only works once it's open).
+   `gh api --method PATCH repos/<owner>/<repo>/pulls/<child> -f state=open`
+3. Retarget it: `gh pr edit <child> --base main` (only works once it's open).
 
 ### Other gotchas
 


### PR DESCRIPTION
Harden the "Recovery if a child PR gets closed by base-branch deletion" step in the stacked-PR runbook so it resolves the correct SHA regardless of what has landed on `main` since.

The restore command used `git rev-parse origin/main^2` to recover the child's merge-commit second parent. That's only correct while the child's merge is still `main`'s tip — once any later PR merges, or the tip is a squash/rebase commit, `origin/main^2` points at an unrelated merge's second parent and restores the wrong branch head. The step now resolves the merge commit from the closed PR itself (`gh pr view <n> --json mergeCommit`) and takes *its* second parent.

Surfaced by Copilot on the marketing team's port of this same runbook (`taskless/public#9`). Fixing it here since this `CLAUDE.md` is the upstream copy — it flows down to `public` and `taskless/taskless`. The two other Copilot findings on that PR (the `github.paginate` `workflow_runs`/`jobs` comments) were false positives — `paginate` normalizes namespaced list responses to flat arrays — and were replied to and resolved there.

Docs-only; no release note (carries `skip-changeset`).