### PR TITLE
docs: declare PR delivery shape in every OpenSpec proposal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,23 @@ The two rules that cause the most damage when missed:
 
 ## Stacked PRs
 
-Committing a branch straight to `main` is the norm — stacks are optional. When PRs _do_ stack, the **stack-breadcrumb workflow** (`.github/workflows/stack-breadcrumb.yml`) keeps their cross-links and carried-forward bodies in sync automatically; there is no git-town or other stacking tool in the loop. Branch protection lives on `main` only (`Validate` required, `strict_up_to_date: true`, 0 required reviews); child branches are unprotected. When you do land a stack, follow these practices.
+When PRs stack, the **stack-breadcrumb workflow** (`.github/workflows/stack-breadcrumb.yml`) keeps their cross-links and carried-forward bodies in sync automatically; there is no git-town or other stacking tool in the loop. Branch protection lives on `main` only (`Validate` required, `strict_up_to_date: true`, 0 required reviews); child branches are unprotected. When you do land a stack, follow these practices.
+
+### Every OpenSpec proposal declares its delivery shape
+
+The proposal states which of these the change is, and why. Decide it while writing the proposal, not when the diff has already grown too big to review.
+
+| Shape                        | When                                                                                                      | How it lands                                                                                                                                        |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Single PR**                | The whole change fits one reviewable diff.                                                                | Spec, implementation, and the archive land together.                                                                                                |
+| **Stacked, merging forward** | Each unit is independently safe in production.                                                            | Each PR merges to `main` in turn; the last one archives the change.                                                                                 |
+| **Stacked, merging down**    | The units are only correct together — an intermediate state would ship a broken or half-migrated product. | Merge each PR **down** into its parent from the tip, then one protected merge of the bottom branch to `main`. The change reaches `main` atomically. |
+
+**Prefer stacking, and aim to keep an individual diff under ~300 lines.** A 900-line PR does not get reviewed, it gets approved. Tests count toward the total but never split from the code they cover — if a unit is oversized because of its tests, that is usually a sign the unit itself should be smaller.
+
+The deciding question between forward and down is only this: **can each unit reach production on its own without breaking anything?** If landing unit 1 alone would leave `check` broken, tests failing, or a migration half-applied, the answer is no and the stack merges down. Do not assume forward because it is tidier — verify it, since "each unit is safe" is a claim about behavior, not intent.
+
+Note how this interacts with the archive gate (see the OpenSpec archive check below): a change is archived exactly once, on whichever PR is the tip. Mid-stack PRs are expected to carry an unarchived change directory and the gate skips them.
 
 ### Landing a stack: merge _down_, then one merge to `main`
 


### PR DESCRIPTION
Every OpenSpec proposal now has to say how it intends to land: a single PR, a stack that merges forward, or a stack that merges down. The point is to decide it while writing the proposal, when the change is still an outline, rather than discovering at review time that the diff is 900 lines and nobody wants to read it.

The distinction between the two stacked shapes is one question, and it is a question about behavior rather than intent: **can each unit reach production on its own without breaking anything?** If yes, the PRs merge forward to `main` one at a time. If landing unit 1 alone would leave `check` broken, tests failing, or a migration half-applied, the answer is no and the stack merges down into its bottom branch to reach `main` atomically.

We already have a worked example. `partition-rules-by-engine`'s first task group is implemented and leaves **20 tests failing** — migration `0004` moves rules out from under readers that later groups update. Nothing is wrong with that work; it simply cannot be a forward stack, and the proposal should have said so before the code existed rather than after.

The guidance is to prefer stacking and aim under ~300 lines per diff, with the caveat that tests count toward the total but never get split from the code they cover — a unit that is oversized *because* of its tests is usually a unit that should have been smaller.

Also removes "stacks are optional" from the section opening, which contradicted the preference now stated a few lines below it.

Nothing here changes the mechanics of landing a stack; the existing merge-down instructions and the archive-gate interaction are unchanged, and the new section points at both.
