### PR TITLE
fix(worktrees): read the worktree id from .name as well as .worktree_id

### DIFF
--- a/.agents/skills/worktrees-pnpm/SKILL.md
+++ b/.agents/skills/worktrees-pnpm/SKILL.md
@@ -109,8 +109,15 @@ printf '{"hook_event_name":"WorktreeCreate","cwd":"%s","worktree_id":"probe"}' "
   | .agents/skills/worktrees-pnpm/scripts/worktree-create.sh
 # expect: <repo>/worktrees/probe on stdout, git chatter on stderr, exit 0
 
+# The id field is not stable across callers, so .worktreeId and .name are read
+# too — `.name` is what a background agent's payload actually carries.
+printf '{"hook_event_name":"WorktreeCreate","cwd":"%s","name":"probe-name"}' "$PWD" \
+  | .agents/skills/worktrees-pnpm/scripts/worktree-create.sh
+# expect: <repo>/worktrees/probe-name
+
 printf '{"hook_event_name":"WorktreeRemove","worktree_path":"%s"}' "$PWD/worktrees/probe" \
   | .agents/skills/worktrees-pnpm/scripts/worktree-remove.sh
+# ...and the same for worktrees/probe-name
 ```
 
 **2. Add the ignores** described in the next section. Skipping this is the single most common way

--- a/.agents/skills/worktrees-pnpm/scripts/worktree-create.sh
+++ b/.agents/skills/worktrees-pnpm/scripts/worktree-create.sh
@@ -18,12 +18,17 @@
 # Layout: /path/to/<repo>  ->  /path/to/<repo>/worktrees/<worktree_id>
 #
 # Contract (docs: code.claude.com/docs/en/hooks):
-#   stdin  - JSON identifying the worktree, plus .cwd, .session_id, ...
+#   stdin  - JSON identifying the worktree, plus .base_path, .cwd, .session_id, ...
 #            The id field is NOT stable across callers: a background agent's
 #            payload carries `.name` (e.g. "agent-a5e1de46e730bdfd7") and no
-#            `.worktree_id` at all, so both are read. Accepting only one of them
+#            `.worktree_id` at all, so all three spellings are read
+#            (.worktree_id, .worktreeId, .name). Accepting only one of them
 #            fails worktree creation outright with a message that reads like the
-#            harness sent nothing.
+#            harness sent nothing. `.name` is the weakest of the three — it is
+#            justified by one captured payload, not a guaranteed contract — so a
+#            caller that sends an unrelated `.name` while genuinely lacking both
+#            id fields lands on the validation below and fails loudly, which is
+#            the intended floor rather than an accident.
 #   stdout - the absolute path of the created worktree, plain text, REQUIRED
 #   exit   - non-zero, or zero with empty stdout, fails worktree creation
 # This hook replaces the default logic entirely, so it must run `git worktree add`.

--- a/.agents/skills/worktrees-pnpm/scripts/worktree-create.sh
+++ b/.agents/skills/worktrees-pnpm/scripts/worktree-create.sh
@@ -18,16 +18,21 @@
 # Layout: /path/to/<repo>  ->  /path/to/<repo>/worktrees/<worktree_id>
 #
 # Contract (docs: code.claude.com/docs/en/hooks):
-#   stdin  - JSON with .worktree_id (and .base_path, .cwd, .session_id, ...)
+#   stdin  - JSON identifying the worktree, plus .cwd, .session_id, ...
+#            The id field is NOT stable across callers: a background agent's
+#            payload carries `.name` (e.g. "agent-a5e1de46e730bdfd7") and no
+#            `.worktree_id` at all, so both are read. Accepting only one of them
+#            fails worktree creation outright with a message that reads like the
+#            harness sent nothing.
 #   stdout - the absolute path of the created worktree, plain text, REQUIRED
 #   exit   - non-zero, or zero with empty stdout, fails worktree creation
 # This hook replaces the default logic entirely, so it must run `git worktree add`.
 set -euo pipefail
 
 payload=$(cat)
-worktree_id=$(printf '%s' "$payload" | jq -r '.worktree_id // empty')
+worktree_id=$(printf '%s' "$payload" | jq -r '.worktree_id // .worktreeId // .name // empty')
 if [ -z "$worktree_id" ]; then
-  echo "WorktreeCreate: no .worktree_id on stdin" >&2
+  echo "WorktreeCreate: stdin carried none of .worktree_id/.worktreeId/.name" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Delegating to a background agent with worktree isolation failed outright with `WorktreeCreate: no .worktree_id on stdin`. Because this hook replaces Claude Code's default creation logic, a non-zero exit means no worktree is created and the agent never starts — so worktree-isolated delegation was simply unavailable.

The payload for that path carries `.name` (e.g. `agent-a5e1de46e730bdfd7`) and no `.worktree_id` at all. That was captured from a real invocation rather than inferred: the hook was temporarily made to dump stdin on failure, the delegation was re-run, and the saved JSON had keys `cwd`, `hook_event_name`, `name`, `prompt_id`, `session_id`, `transcript_path`.

The hook now reads `.worktree_id`, `.worktreeId`, or `.name`, and its contract comment records that the id field is **not** stable across callers — worth stating, because the previous failure message read as though the harness had sent nothing at all, which sends you looking in the wrong place.

Verified by re-running the delegation against the fixed hook: the worktree was created at `worktrees/agent-af8378fb661401c98` and the agent completed its work inside it.

One related thing left alone deliberately: `worktree-remove.sh` reads `.worktree_path`, which may be subject to the same drift. It fails open — a missing field just leaves the worktree in place — so the symptom is a stale directory rather than lost work, and I did not want to guess at a fallback that could resolve to something removable. Worth confirming separately against a real remove payload.
