### PR TITLE
fix(cli): size the vitest timeout to what the suite actually does

### DIFF
--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -170,4 +170,22 @@ export default defineConfig({
       external: [/^node:/, ...builtinModules],
     },
   },
+  // Much of this suite is integration-shaped rather than unit-shaped: tests in
+  // check/runtime-check/init/onboard spawn the real built CLI via
+  // `execFile("node", [binPath, ...])`, and several lay out a fixture tree and
+  // run `git init` first. One cold CLI spawn measures ~0.8s by itself, so a test
+  // doing four or five of them sits at 3-4s before any load at all.
+  //
+  // Vitest's default 5s testTimeout left no margin for that. Since vitest runs
+  // test files in parallel workers competing for CPU, whichever tests happened
+  // to land together tipped over: a different set failed on each run, always
+  // with "Test timed out in 5000ms" and never an assertion. Verified against a
+  // clean checkout of `main` with no local changes, where 8 tests failed this
+  // way, so it is the suite's own sizing rather than any one change.
+  //
+  // 20s swallows the contention without hiding a genuine hang.
+  test: {
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
+  },
 });


### PR DESCRIPTION
The CLI test suite fails a rotating handful of tests on every run, always with `Test timed out in 5000ms` and never an assertion failure. It is not flaky code. The timeout is sized below the work.

Much of this suite is integration-shaped rather than unit-shaped. Tests in `check`, `runtime-check`, `init`, and `onboard` spawn the real built CLI through `execFile("node", [binPath, ...])`, and several lay out a fixture tree and run `git init` first. One cold CLI spawn measures ~0.8s on its own, so a test doing four or five of them sits at 3-4s before any load at all. Vitest runs test files in parallel workers that compete for CPU, so whichever tests happen to land together are the ones that tip over, which is why the failing set changes run to run.

This raises `testTimeout` and `hookTimeout` to 20s. That swallows the contention without hiding a genuine hang.

## Evidence it predates every open branch

Checked out `origin/main` at `d7abf6a` with no local changes and no merge, ran the suite, and got 8 failures, all timeouts. So this is the suite's own sizing rather than anything a current branch introduced.

With the change, `packages/cli` passes 427/427 across three consecutive runs.

## Note for reviewers

`packages/cli` has no `vitest.config.ts`; vitest reads `vite.config.ts`, which had no `test` block, so the 5s default applied. The new block is test-only configuration and does not affect the published bundle.

Worth knowing separately: running `vitest` without building first fails ~119 tests, because the integration tests spawn `dist/index.js`. `turbo` handles this via `test.dependsOn: ["build"]`, so `pnpm test` at the root is fine; a bare `pnpm --filter @taskless/cli test` in a fresh checkout is not.